### PR TITLE
Fix vistani kukri range to multi

### DIFF
--- a/Output/EnhancementTrees/Vistani.xml
+++ b/Output/EnhancementTrees/Vistani.xml
@@ -135,9 +135,9 @@ You gain +5% Doublestrike and Doubleshot.</Description>
       <EnhancementTreeItem>
          <Name>Vistani: One With Blades</Name>
          <InternalName>VistaniCore4</InternalName>
-         <Description>You gain a +1 Competence bonus to Critical Threat Range with Daggers, Kukris,
+         <Description>You gain a +1 Competence bonus to Critical Damage Multiplier with Daggers, Kukris,
 and Throwing Daggers. Daggers and Throwing Daggers also gain a +1 Competence
-bonus to Critical Damage Multiplier.</Description>
+bonus to Critical Threat Range.</Description>
          <Icon>OneWithBlades</Icon>
          <XPosition>3</XPosition>
          <YPosition>0</YPosition>
@@ -168,7 +168,6 @@ bonus to Critical Damage Multiplier.</Description>
             <Amount>1</Amount>
             <ApplyAsItemEffect/>
             <Weapon>Dagger</Weapon>
-            <Weapon>Kukri</Weapon>
             <Weapon>Throwing Dagger</Weapon>
          </Effect>
       </EnhancementTreeItem>


### PR DESCRIPTION
Fix tooltip to properly show kukri gaining crit multi but NOT range from vistani core 4.

Remove expanded crit range effect on kukri from vistani core 4.